### PR TITLE
fix: Remove broken composer provide rule

### DIFF
--- a/src/Viserio/Component/Profiler/composer.json
+++ b/src/Viserio/Component/Profiler/composer.json
@@ -40,7 +40,6 @@
         "viserio/support": "^1.0@dev"
     },
     "provide": {
-        "psr/http-message": "^1.0.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log-implementation": "^1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Refs composer/composer#9316
| License       | MIT
| Doc PR        | n/a

This package does not provide the definition for the PSR interfaces.

Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that installing psr/http-message is not necessary as it is already provided.
