### PR TITLE
fix: Remove broken composer provide rules

### DIFF
--- a/src/Viserio/Component/Session/composer.json
+++ b/src/Viserio/Component/Session/composer.json
@@ -38,11 +38,6 @@
         "viserio/session-contract": "^1.0@dev",
         "viserio/support": "^1.0@dev"
     },
-    "provide": {
-        "psr/container-implementation": "^1.0",
-        "psr/http-message": "^1.0.0",
-        "psr/http-message-implementation": "^1.0"
-    },
     "require-dev": {
         "ext-pdo": "*",
         "cache/filesystem-adapter": "^1.0.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/Viserio/**/**/CHANGELOG.md files -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tickets       | Refs composer/composer#9316
| License       | MIT
| Doc PR        | n/a

The session component does not provide the psr/http-message interfaces. It does not even provide an implementation of these interfaces (and neither of the PSR container interfaces).
Lying about provided packages will cause issues as composer might not install `psr/http-message` when other packages need it, by thing that `viserio/session` already fills the need. And Composer 2 is more likely to be affected than Composer 1 as it respects `provide` more than Composer 1.